### PR TITLE
Add next alarm sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,13 @@ sleep as android status is my solution for wake/sleep state within HA. it listen
 <ul>
   <li>
     <details>
-      <summary><strong>📡 8 sensors</strong></summary>
+      <summary><strong>📡 9 sensors</strong></summary>
       <ul>
         <li>message received *state*</li>
         <li>wake status</li>
         <li>sound</li>
         <li>disturbance</li>
+        <li>next alarm</li>
         <li>alarm</li>
         <li>lullaby</li>
         <li>sleep tracking</li>


### PR DESCRIPTION
## Summary
- add new `SAASNextAlarmSensor` to track upcoming alarm time and label via `alarm_rescheduled` event
- register the new sensor when setting up the integration
- mention the sensor in docs

## Testing
- `python -m py_compile custom_components/saas/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6860b3b0805c8332a11e272d895bbd8c